### PR TITLE
Feature vr followheadrot

### DIFF
--- a/Assets/Scripts/TES/PlayerComponent.cs
+++ b/Assets/Scripts/TES/PlayerComponent.cs
@@ -97,6 +97,19 @@ namespace TESUnity
             {
                 ApplyAirborneForce();
             }
+
+            //if (TESUnity.instance.followHeadRotation)
+            {
+                var centerEye = Camera.main.transform;
+                var root = centerEye.parent;
+                var prevPos = root.position;
+                var prevRot = root.rotation;
+
+                transform.rotation = Quaternion.Euler(0.0f, centerEye.rotation.eulerAngles.y, 0.0f);
+
+                root.position = prevPos;
+                root.rotation = prevRot;
+            }
         }
 
         private void Rotate()

--- a/Assets/Scripts/TES/PlayerComponent.cs
+++ b/Assets/Scripts/TES/PlayerComponent.cs
@@ -98,7 +98,7 @@ namespace TESUnity
                 ApplyAirborneForce();
             }
 
-            //if (TESUnity.instance.followHeadRotation)
+            if (TESUnity.instance.followHeadDirection)
             {
                 var centerEye = Camera.main.transform;
                 var root = centerEye.parent;

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -3,7 +3,7 @@
 --- !u!30 &1
 GraphicsSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 7
   m_Deferred:
     m_Mode: 1
     m_Shader: {fileID: 69, guid: 0000000000000000f000000000000000, type: 0}
@@ -43,18 +43,22 @@ GraphicsSettings:
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
-  m_TierSettings_Tier1:
-    renderingPath: 1
+  m_ShaderSettings_Tier1:
     useCascadedShadowMaps: 1
-  m_TierSettings_Tier2:
-    renderingPath: 1
+    standardShaderQuality: 2
+    useReflectionProbeBoxProjection: 1
+    useReflectionProbeBlending: 1
+  m_ShaderSettings_Tier2:
     useCascadedShadowMaps: 1
-  m_TierSettings_Tier3:
-    renderingPath: 1
+    standardShaderQuality: 2
+    useReflectionProbeBoxProjection: 1
+    useReflectionProbeBlending: 1
+  m_ShaderSettings_Tier3:
     useCascadedShadowMaps: 1
-  m_DefaultRenderingPath: 1
-  m_DefaultMobileRenderingPath: 1
-  m_TierSettings: []
+    standardShaderQuality: 2
+    useReflectionProbeBoxProjection: 1
+    useReflectionProbeBlending: 1
+  m_BuildTargetShaderSettings: []
   m_LightmapStripping: 0
   m_FogStripping: 0
   m_LightmapKeepPlain: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -462,7 +462,7 @@ PlayerSettings:
   PSM::VR::enable: 0
   PSP2::VR::enable: 0
   SamsungTV::VR::enable: 0
-  Standalone::VR::enable: 0
+  Standalone::VR::enable: 1
   Tizen::VR::enable: 0
   WebGL::VR::enable: 0
   WebGL::analyzeBuildSize: 0
@@ -529,6 +529,7 @@ PlayerSettings:
   SamsungTV::VR::enabledDevices: []
   Standalone::VR::enabledDevices:
   - Oculus
+  - OpenVR
   Tizen::VR::enabledDevices: []
   WebGL::VR::enabledDevices: []
   WebPlayer::VR::enabledDevices: []

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,2 @@
-m_EditorVersion: 5.5.0b5
+m_EditorVersion: 5.4.1p3
+m_StandardAssetsVersion: 0


### PR DESCRIPTION
Hi,

When you play in VR you can want that the player goes in the direction of your head, especially when you don't play seated. Using the `followHeadDirection` parameter introduced in a previous commit enables this feature.
